### PR TITLE
Add all_schemas/names, add some tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "iuliia-rust"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "include_dir",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iuliia-rust"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["Kilin Maksim <https://github.com/massita99>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Transliteration means representing Cyrillic data (mainly names and geographic lo
 iuliia_rust::parse_by_schema_name("Юлия", "wikipedia") -> Yuliya
 ```
 
+Get all schemas by:
+
+```rust
+iuliia_rust::Schema::all_schemas() -> Vec<Schema>
+```
+
+Or all schema names:
+
+```rust
+iuliia_rust::Schema::all_schema_names() -> Vec<&str>
+```
+
 ## Why use `Iuliia`
 
 - [20 transliteration schemas](https://github.com/nalgeon/iuliia) (rule sets), including all main international and Russian standards.
@@ -24,7 +36,7 @@ iuliia_rust::parse_by_schema_name("Юлия", "wikipedia") -> Yuliya
 Cargo.toml:
 ```toml
 [dependencies]
-iuliia-rust = "0.1.0"
+iuliia-rust = "^0.1.0"
 ```
 
 ## Contributing


### PR DESCRIPTION
I decided to add some minor things, please, take a look.

I've added some more tests:
- [x] should_panic for non-existing schema
- [x] stack of tests based on samples shipped with the schemas

I also added  `all_schema_names` / `all_schemas` methods, so user will be able to get all available schemas. This one requires some attention, I'm new to Rust and I'm not sure will those methods be available as `iuliia_rust::Schema::all_schemas()` or not.